### PR TITLE
Fix filter reset when switching tabs

### DIFF
--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -277,13 +277,25 @@ function ConfigPage() {
       <div className="tabs">
         <button
           className={activeTab === "scales" ? "active" : ""}
-          onClick={() => setActiveTab("scales")}
+          onClick={() => {
+            if (activeTab !== "scales") {
+              setTypeFilter("");
+              setOctaveFilter("");
+            }
+            setActiveTab("scales");
+          }}
         >
           Scales
         </button>
         <button
           className={activeTab === "arpeggios" ? "active" : ""}
-          onClick={() => setActiveTab("arpeggios")}
+          onClick={() => {
+            if (activeTab !== "arpeggios") {
+              setTypeFilter("");
+              setOctaveFilter("");
+            }
+            setActiveTab("arpeggios");
+          }}
         >
           Arpeggios
         </button>


### PR DESCRIPTION
## Summary
- Reset type and octave filters when switching between scales and arpeggios tabs
- Prevents empty lists when filter values are incompatible between tabs
- Fixes #8

## Test plan
- [ ] Select a type filter on scales tab (e.g., "chromatic")
- [ ] Switch to arpeggios tab
- [ ] Verify the list shows items (filter was reset)
- [ ] Repeat with octave filter

🤖 Generated with [Claude Code](https://claude.ai/code)