### PR TITLE
Fix minor filter label for arpeggios

### DIFF
--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -322,7 +322,9 @@ function ConfigPage() {
                 {(activeTab === "scales" ? SCALE_TYPES : ARPEGGIO_TYPES).map(
                   (type) => (
                     <option key={type} value={type}>
-                      {type === "minor" ? "minor (all)" : type.replace("_", " ")}
+                      {type === "minor" && activeTab === "scales"
+                        ? "minor (all)"
+                        : type.replace("_", " ")}
                     </option>
                   )
                 )}


### PR DESCRIPTION
## Summary
- Only show "minor (all)" label on scales tab where it filters multiple types
- Shows just "minor" on arpeggios tab since there's only one minor type
- Fixes #9

## Test plan
- [ ] Go to scales tab, verify type dropdown shows "minor (all)"
- [ ] Go to arpeggios tab, verify type dropdown shows "minor" (without "(all)")

🤖 Generated with [Claude Code](https://claude.ai/code)