### PR TITLE
Fix Safari slider touch handling

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -267,15 +267,24 @@ tr:hover {
   margin-bottom: 0.75rem;
 }
 
-/* Weight slider */
+/* Weight slider - Safari touch compatibility */
 .weight-control {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  touch-action: pan-y pinch-zoom;
 }
 
 .weight-control input[type="range"] {
   width: 80px;
+  -webkit-appearance: none;
+  touch-action: manipulation;
+}
+
+.legend-control input[type="range"],
+.variation-control input[type="range"] {
+  -webkit-appearance: none;
+  touch-action: manipulation;
 }
 
 .weight-control span {


### PR DESCRIPTION
## Summary
- Replace onMouseUp/onTouchEnd with unified Pointer Events for better Safari iPad compatibility
- Use null localValue pattern to track interaction state without useEffect
- Add debounced onChange fallback for Safari edge cases
- Add touch-action CSS for better touch event handling

## Test plan
- [ ] Test slider on Safari iPad (physical device or BrowserStack)
- [ ] Verify slider responds to touch drag smoothly
- [ ] Verify value commits correctly on touch end
- [ ] Verify no regression on Chrome/Firefox desktop

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)