### PR TITLE
Add scale/arpeggio category chips to weekly focus config (#47)

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -141,6 +141,7 @@ DEFAULT_ALGORITHM_CONFIG: dict[str, Any] = {
         "enabled": False,
         "keys": [],  # e.g., ["A", "B"]
         "types": [],  # e.g., ["dominant", "diminished", "chromatic"]
+        "categories": [],  # e.g., ["scale", "arpeggio"]
         "probability_increase": 80,  # 0-100
     },
 }

--- a/frontend/src/pages/ConfigPage.tsx
+++ b/frontend/src/pages/ConfigPage.tsx
@@ -630,6 +630,7 @@ function ConfigPage() {
                         ...(algorithmConfig.weekly_focus || {
                           keys: [],
                           types: [],
+                          categories: [],
                           probability_increase: 80,
                         }),
                         enabled: e.target.checked,
@@ -708,6 +709,50 @@ function ConfigPage() {
                               {type.replace("_", " ")}
                             </button>
                           ))}
+                      </div>
+                    </div>
+                    <div className="focus-group">
+                      <label>Focus Categories:</label>
+                      <div className="chip-container">
+                        {(["scale", "arpeggio"] as const).map((category) => (
+                          <button
+                            key={category}
+                            className={`chip ${
+                              algorithmConfig.weekly_focus.categories?.includes(
+                                category
+                              )
+                                ? "active"
+                                : ""
+                            } ${
+                              category === "scale"
+                                ? "tint-tonal"
+                                : "tint-arpeggio"
+                            }`}
+                            onClick={() => {
+                              const categories =
+                                algorithmConfig.weekly_focus.categories?.includes(
+                                  category
+                                )
+                                  ? algorithmConfig.weekly_focus.categories.filter(
+                                      (c) => c !== category
+                                    )
+                                  : [
+                                      ...(algorithmConfig.weekly_focus
+                                        .categories || []),
+                                      category,
+                                    ];
+                              updateAlgorithmMutation.mutate({
+                                ...algorithmConfig,
+                                weekly_focus: {
+                                  ...algorithmConfig.weekly_focus,
+                                  categories,
+                                },
+                              });
+                            }}
+                          >
+                            {category}
+                          </button>
+                        ))}
                       </div>
                     </div>
                   </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -79,6 +79,7 @@ export interface WeeklyFocusConfig {
   enabled: boolean;
   keys: string[];
   types: string[];
+  categories: string[];
   probability_increase: number;
 }
 


### PR DESCRIPTION
Allows users to filter weekly focus by category (scale/arpeggio) in addition to keys and types. Categories act as a filter - if selected, only items in those categories can be focus items. If no categories are selected, all categories are eligible (backward compatible).