### PR TITLE
Add custom BpmSlider component for precise metronome control

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1716,6 +1716,113 @@ tr:hover {
   white-space: nowrap;
 }
 
+/* Custom BPM Slider */
+.bpm-slider-container {
+  width: 100%;
+  padding: 0.5rem 0;
+}
+
+.bpm-slider-track {
+  position: relative;
+  width: 100%;
+  height: 6px;
+  background: #e0e0e0;
+  border-radius: 3px;
+  cursor: pointer;
+  outline: none;
+}
+
+.bpm-slider-track:focus {
+  box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.3);
+}
+
+.bpm-slider-fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: #1976d2;
+  border-radius: 3px;
+  pointer-events: none;
+}
+
+.bpm-slider-thumb {
+  position: absolute;
+  top: 50%;
+  width: 20px;
+  height: 20px;
+  background: #1976d2;
+  border-radius: 50%;
+  cursor: grab;
+  transform: translate(-50%, -50%);
+  transition: box-shadow 0.15s, background 0.15s;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.bpm-slider-thumb:hover {
+  background: #1565c0;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+.bpm-slider-thumb.dragging {
+  cursor: grabbing;
+  background: #1565c0;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.35);
+}
+
+.bpm-slider-tick {
+  position: absolute;
+  top: -3px;
+  width: 2px;
+  height: 12px;
+  background: #bdbdbd;
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.bpm-slider-labels {
+  position: relative;
+  height: 1rem;
+  margin-top: 0.5rem;
+  font-size: 0.7rem;
+  color: #999;
+  padding-bottom: 0.5rem;
+}
+
+.bpm-slider-label {
+  white-space: nowrap;
+}
+
+@media (prefers-color-scheme: dark) {
+  .bpm-slider-track {
+    background: #444;
+  }
+
+  .bpm-slider-fill {
+    background: #42a5f5;
+  }
+
+  .bpm-slider-thumb {
+    background: #42a5f5;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  }
+
+  .bpm-slider-thumb:hover {
+    background: #64b5f6;
+  }
+
+  .bpm-slider-thumb.dragging {
+    background: #64b5f6;
+  }
+
+  .bpm-slider-tick {
+    background: #666;
+  }
+
+  .bpm-slider-labels {
+    color: #666;
+  }
+}
 
 @media (prefers-color-scheme: dark) {
   .metronome {

--- a/frontend/src/components/BpmSlider.tsx
+++ b/frontend/src/components/BpmSlider.tsx
@@ -1,0 +1,212 @@
+import { useRef, useCallback, useEffect, useState } from "react";
+
+interface BpmSliderProps {
+  value: number;
+  min: number;
+  max: number;
+  onChange: (value: number) => void;
+  tickMarks?: number[];
+  ariaLabel?: string;
+}
+
+/**
+ * Custom BPM slider component with precise thumb positioning.
+ * Uses a div-based track instead of native range input to ensure
+ * the thumb visually aligns exactly with the displayed BPM value.
+ */
+export function BpmSlider({
+  value,
+  min,
+  max,
+  onChange,
+  tickMarks = [],
+  ariaLabel = "BPM slider",
+}: BpmSliderProps) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  // Calculate thumb position as exact percentage
+  const thumbPosition = ((value - min) / (max - min)) * 100;
+
+  // Convert a position on the track to a BPM value
+  const positionToValue = useCallback(
+    (clientX: number): number => {
+      if (!trackRef.current) return value;
+
+      const rect = trackRef.current.getBoundingClientRect();
+      const position = (clientX - rect.left) / rect.width;
+      const clampedPosition = Math.max(0, Math.min(1, position));
+      const newValue = Math.round(min + clampedPosition * (max - min));
+
+      return Math.max(min, Math.min(max, newValue));
+    },
+    [min, max, value]
+  );
+
+  // Handle click on track
+  const handleTrackClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const newValue = positionToValue(e.clientX);
+      onChange(newValue);
+    },
+    [positionToValue, onChange]
+  );
+
+  // Handle mouse down on thumb
+  const handleThumbMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(true);
+    },
+    []
+  );
+
+  // Handle touch start on thumb
+  const handleThumbTouchStart = useCallback(
+    (e: React.TouchEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      setIsDragging(true);
+    },
+    []
+  );
+
+  // Handle mouse/touch move during drag
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const newValue = positionToValue(e.clientX);
+      onChange(newValue);
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (e.touches.length > 0) {
+        const newValue = positionToValue(e.touches[0].clientX);
+        onChange(newValue);
+      }
+    };
+
+    const handleEnd = () => {
+      setIsDragging(false);
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleEnd);
+    document.addEventListener("touchmove", handleTouchMove, { passive: true });
+    document.addEventListener("touchend", handleEnd);
+
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleEnd);
+      document.removeEventListener("touchmove", handleTouchMove);
+      document.removeEventListener("touchend", handleEnd);
+    };
+  }, [isDragging, positionToValue, onChange]);
+
+  // Handle keyboard navigation
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      let newValue = value;
+
+      switch (e.key) {
+        case "ArrowLeft":
+        case "ArrowDown":
+          newValue = Math.max(min, value - 1);
+          e.preventDefault();
+          break;
+        case "ArrowRight":
+        case "ArrowUp":
+          newValue = Math.min(max, value + 1);
+          e.preventDefault();
+          break;
+        case "Home":
+          newValue = min;
+          e.preventDefault();
+          break;
+        case "End":
+          newValue = max;
+          e.preventDefault();
+          break;
+        case "PageDown":
+          newValue = Math.max(min, value - 10);
+          e.preventDefault();
+          break;
+        case "PageUp":
+          newValue = Math.min(max, value + 10);
+          e.preventDefault();
+          break;
+        default:
+          return;
+      }
+
+      if (newValue !== value) {
+        onChange(newValue);
+      }
+    },
+    [value, min, max, onChange]
+  );
+
+  return (
+    <div className="bpm-slider-container">
+      <div
+        ref={trackRef}
+        className="bpm-slider-track"
+        onClick={handleTrackClick}
+        role="slider"
+        aria-label={ariaLabel}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+      >
+        {/* Filled portion of track */}
+        <div
+          className="bpm-slider-fill"
+          style={{ width: `${thumbPosition}%` }}
+        />
+
+        {/* Tick marks */}
+        {tickMarks.map((tick) => {
+          const tickPosition = ((tick - min) / (max - min)) * 100;
+          return (
+            <div
+              key={tick}
+              className="bpm-slider-tick"
+              style={{ left: `${tickPosition}%` }}
+            />
+          );
+        })}
+
+        {/* Thumb */}
+        <div
+          className={`bpm-slider-thumb ${isDragging ? "dragging" : ""}`}
+          style={{ left: `${thumbPosition}%` }}
+          onMouseDown={handleThumbMouseDown}
+          onTouchStart={handleThumbTouchStart}
+        />
+      </div>
+
+      {/* Labels */}
+      <div className="bpm-slider-labels">
+        {tickMarks.map((tick) => {
+          const tickPosition = ((tick - min) / (max - min)) * 100;
+          return (
+            <span
+              key={tick}
+              className="bpm-slider-label"
+              style={{
+                position: "absolute",
+                left: `${tickPosition}%`,
+                transform: "translateX(-50%)",
+              }}
+            >
+              {tick}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Metronome.tsx
+++ b/frontend/src/components/Metronome.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useMetronome } from "../hooks/useMetronome";
 import { BpmInput } from "./BpmInput";
+import { BpmSlider } from "./BpmSlider";
 import type { BpmUnit } from "../types";
 
 interface MetronomeProps {
@@ -146,33 +147,14 @@ function Metronome({
 
       {isEnabled && (
         <div className="metronome-slider">
-          <input
-            type="range"
+          <BpmSlider
+            value={displayBpm}
             min={minDisplayBpm}
             max={maxDisplayBpm}
-            value={displayBpm}
-            onChange={(e) => handleDisplayBpmChange(Number(e.target.value))}
-            className="metronome-slider-input"
+            onChange={handleDisplayBpmChange}
+            tickMarks={sliderLabels}
+            ariaLabel={`BPM slider, current value ${displayBpm}`}
           />
-
-          <div className="metronome-slider-labels">
-            {sliderLabels.map((value) => {
-              const left = ((value - minDisplayBpm) / (maxDisplayBpm - minDisplayBpm)) * 100;
-              return (
-                <span
-                  key={value}
-                  className="metronome-slider-label"
-                  style={{
-                    position: "absolute",
-                    left: `${left}%`,
-                    transform: "translateX(-50%)",
-                  }}
-                >
-                  {value}
-                </span>
-              );
-            })}
-          </div>
         </div>
       )}
     </div>

--- a/frontend/src/tests/BpmSlider.test.tsx
+++ b/frontend/src/tests/BpmSlider.test.tsx
@@ -1,0 +1,317 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BpmSlider } from "../components/BpmSlider";
+
+describe("BpmSlider Component", () => {
+  const defaultProps = {
+    value: 60,
+    min: 20,
+    max: 240,
+    onChange: vi.fn(),
+    tickMarks: [20, 60, 120, 180, 240],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Rendering", () => {
+    it("should render with correct ARIA attributes", () => {
+      render(<BpmSlider {...defaultProps} />);
+
+      const slider = screen.getByRole("slider");
+      expect(slider).toBeInTheDocument();
+      expect(slider).toHaveAttribute("aria-valuemin", "20");
+      expect(slider).toHaveAttribute("aria-valuemax", "240");
+      expect(slider).toHaveAttribute("aria-valuenow", "60");
+    });
+
+    it("should render with custom aria-label", () => {
+      render(<BpmSlider {...defaultProps} ariaLabel="Custom BPM control" />);
+
+      const slider = screen.getByRole("slider");
+      expect(slider).toHaveAttribute("aria-label", "Custom BPM control");
+    });
+
+    it("should render tick marks", () => {
+      const { container } = render(<BpmSlider {...defaultProps} />);
+
+      const ticks = container.querySelectorAll(".bpm-slider-tick");
+      expect(ticks).toHaveLength(5);
+    });
+
+    it("should render labels for tick marks", () => {
+      render(<BpmSlider {...defaultProps} />);
+
+      expect(screen.getByText("20")).toBeInTheDocument();
+      expect(screen.getByText("60")).toBeInTheDocument();
+      expect(screen.getByText("120")).toBeInTheDocument();
+      expect(screen.getByText("180")).toBeInTheDocument();
+      expect(screen.getByText("240")).toBeInTheDocument();
+    });
+
+    it("should render without tick marks when not provided", () => {
+      const { container } = render(
+        <BpmSlider value={60} min={20} max={240} onChange={vi.fn()} />
+      );
+
+      const ticks = container.querySelectorAll(".bpm-slider-tick");
+      expect(ticks).toHaveLength(0);
+    });
+  });
+
+  describe("Thumb positioning", () => {
+    it("should position thumb at 0% when value equals min", () => {
+      const { container } = render(
+        <BpmSlider {...defaultProps} value={20} />
+      );
+
+      const thumb = container.querySelector(".bpm-slider-thumb");
+      expect(thumb).toHaveStyle({ left: "0%" });
+    });
+
+    it("should position thumb at 100% when value equals max", () => {
+      const { container } = render(
+        <BpmSlider {...defaultProps} value={240} />
+      );
+
+      const thumb = container.querySelector(".bpm-slider-thumb");
+      expect(thumb).toHaveStyle({ left: "100%" });
+    });
+
+    it("should position thumb at correct percentage for middle values", () => {
+      // For value=130, min=20, max=240: (130-20)/(240-20) = 110/220 = 50%
+      const { container } = render(
+        <BpmSlider {...defaultProps} value={130} />
+      );
+
+      const thumb = container.querySelector(".bpm-slider-thumb");
+      expect(thumb).toHaveStyle({ left: "50%" });
+    });
+
+    it("should update fill width to match thumb position", () => {
+      const { container } = render(
+        <BpmSlider {...defaultProps} value={130} />
+      );
+
+      const fill = container.querySelector(".bpm-slider-fill");
+      expect(fill).toHaveStyle({ width: "50%" });
+    });
+  });
+
+  describe("Keyboard navigation", () => {
+    it("should increase value with ArrowRight", () => {
+      const onChange = vi.fn();
+      render(<BpmSlider {...defaultProps} onChange={onChange} />);
+
+      const slider = screen.getByRole("slider");
+      fireEvent.keyDown(slider, { key: "ArrowRight" });
+
+      expect(onChange).toHaveBeenCalledWith(61);
+    });
+
+    it("should decrease value with ArrowLeft", () => {
+      const onChange = vi.fn();
+      render(<BpmSlider {...defaultProps} onChange={onChange} />);
+
+      const slider = screen.getByRole("slider");
+      fireEvent.keyDown(slider, { key: "ArrowLeft" });
+
+      expect(onChange).toHaveBeenCalledWith(59);
+    });
+
+    it("should increase value with ArrowUp", () => {
+      const onChange = vi.fn();
+      render(<BpmSlider {...defaultProps} onChange={onChange} />);
+
+      const slider = screen.getByRole("slider");
+      fireEvent.keyDown(slider, { key: "ArrowUp" });
+
+      expect(onChange).toHaveBeenCalledWith(61);
+    });
+
+    it("should decrease value with ArrowDown", () => {
+      const onChange = vi.fn();
+      render(<BpmSlider {...defaultProps} onChange={onChange} />);
+
+      const slider = screen.getByRole("slider");
+      fireEvent.keyDown(slider, { key: "ArrowDown" });
+
+      expect(onChange).toHaveBeenCalledWith(59);
+    });
+
+    it("should jump to min with Home key", () => {
+      const onChange = vi.fn();
+      render(<BpmSlider {...defaultProps} onChange={onChange} />);
+
+      const slider = screen.getByRole("slider");
+      fireEvent.keyDown(slider, { key: "Home" });
+
+      expect(onChange).toHaveBeenCalledWith(20);
+    });
+
+    it("should jump to max with End key", () => {
+      const onChange = vi.fn();
+      render(<BpmSlider {...defaultProps} onChange={onChange} />);
+
+      const slider = screen.getByRole("slider");
+      fireEvent.keyDown(slider, { key: "End" });
+
+      expect(onChange).toHaveBeenCalledWith(240);
+    });
+
+    it("should decrease by 10 with PageDown", () => {
+      const onChange = vi.fn();
+      render(<BpmSlider {...defaultProps} onChange={onChange} />);
+
+      const slider = screen.getByRole("slider");
+      fireEvent.keyDown(slider, { key: "PageDown" });
+
+      expect(onChange).toHaveBeenCalledWith(50);
+    });
+
+    it("should increase by 10 with PageUp", () => {
+      const onChange = vi.fn();
+      render(<BpmSlider {...defaultProps} onChange={onChange} />);
+
+      const slider = screen.getByRole("slider");
+      fireEvent.keyDown(slider, { key: "PageUp" });
+
+      expect(onChange).toHaveBeenCalledWith(70);
+    });
+
+    it("should not go below min value", () => {
+      const onChange = vi.fn();
+      render(<BpmSlider {...defaultProps} value={20} onChange={onChange} />);
+
+      const slider = screen.getByRole("slider");
+      fireEvent.keyDown(slider, { key: "ArrowLeft" });
+
+      // onChange should not be called when value can't change
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("should not go above max value", () => {
+      const onChange = vi.fn();
+      render(<BpmSlider {...defaultProps} value={240} onChange={onChange} />);
+
+      const slider = screen.getByRole("slider");
+      fireEvent.keyDown(slider, { key: "ArrowRight" });
+
+      // onChange should not be called when value can't change
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("should not call onChange for unhandled keys", () => {
+      const onChange = vi.fn();
+      render(<BpmSlider {...defaultProps} onChange={onChange} />);
+
+      const slider = screen.getByRole("slider");
+      fireEvent.keyDown(slider, { key: "a" });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Mouse interactions", () => {
+    it("should add dragging class when mouse is pressed on thumb", () => {
+      const { container } = render(<BpmSlider {...defaultProps} />);
+
+      const thumb = container.querySelector(".bpm-slider-thumb")!;
+      fireEvent.mouseDown(thumb);
+
+      expect(thumb).toHaveClass("dragging");
+    });
+
+    it("should remove dragging class on mouse up", () => {
+      const { container } = render(<BpmSlider {...defaultProps} />);
+
+      const thumb = container.querySelector(".bpm-slider-thumb")!;
+      fireEvent.mouseDown(thumb);
+      fireEvent.mouseUp(document);
+
+      expect(thumb).not.toHaveClass("dragging");
+    });
+  });
+
+  describe("Touch interactions", () => {
+    it("should add dragging class when touch starts on thumb", () => {
+      const { container } = render(<BpmSlider {...defaultProps} />);
+
+      const thumb = container.querySelector(".bpm-slider-thumb")!;
+      fireEvent.touchStart(thumb);
+
+      expect(thumb).toHaveClass("dragging");
+    });
+
+    it("should remove dragging class on touch end", () => {
+      const { container } = render(<BpmSlider {...defaultProps} />);
+
+      const thumb = container.querySelector(".bpm-slider-thumb")!;
+      fireEvent.touchStart(thumb);
+      fireEvent.touchEnd(document);
+
+      expect(thumb).not.toHaveClass("dragging");
+    });
+  });
+
+  describe("Crotchet mode (half values)", () => {
+    it("should work with crotchet range (10-120)", () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <BpmSlider
+          value={60}
+          min={10}
+          max={120}
+          onChange={onChange}
+          tickMarks={[10, 30, 60, 90, 120]}
+        />
+      );
+
+      const slider = screen.getByRole("slider");
+      expect(slider).toHaveAttribute("aria-valuemin", "10");
+      expect(slider).toHaveAttribute("aria-valuemax", "120");
+      expect(slider).toHaveAttribute("aria-valuenow", "60");
+
+      // Thumb should be at 50% for value 60 in range 10-120
+      // (60-10)/(120-10) = 50/110 ≈ 45.45%
+      const thumb = container.querySelector(".bpm-slider-thumb");
+      const expectedPosition = ((60 - 10) / (120 - 10)) * 100;
+      expect(thumb).toHaveStyle({ left: `${expectedPosition}%` });
+    });
+
+    it("should render crotchet tick marks", () => {
+      render(
+        <BpmSlider
+          value={60}
+          min={10}
+          max={120}
+          onChange={vi.fn()}
+          tickMarks={[10, 30, 60, 90, 120]}
+        />
+      );
+
+      expect(screen.getByText("10")).toBeInTheDocument();
+      expect(screen.getByText("30")).toBeInTheDocument();
+      expect(screen.getByText("60")).toBeInTheDocument();
+      expect(screen.getByText("90")).toBeInTheDocument();
+      expect(screen.getByText("120")).toBeInTheDocument();
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("should be focusable", () => {
+      render(<BpmSlider {...defaultProps} />);
+
+      const slider = screen.getByRole("slider");
+      expect(slider).toHaveAttribute("tabIndex", "0");
+    });
+
+    it("should have proper role", () => {
+      render(<BpmSlider {...defaultProps} />);
+
+      const slider = screen.getByRole("slider");
+      expect(slider).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replace HTML5 range input with custom div-based slider component
- Ensures slider thumb visually aligns exactly with displayed BPM value
- Add visual tick marks at key BPM values (quaver: 20, 60, 120, 180, 240; crotchet: 10, 30, 60, 90, 120)
- Full keyboard accessibility and cross-browser consistency

## Changes
- **New component**: `frontend/src/components/BpmSlider.tsx` - Custom slider with:
  - Div-based track with calculated thumb position using exact percentage
  - Mouse and touch drag support
  - Keyboard navigation (arrow keys, Home/End, PageUp/PageDown)
  - Dark mode styling
- **New tests**: `frontend/src/tests/BpmSlider.test.tsx` - 28 test cases covering:
  - Rendering and ARIA attributes
  - Thumb positioning accuracy
  - Keyboard navigation
  - Mouse/touch interactions
  - Crotchet mode support
  - Accessibility
- **Updated**: `frontend/src/components/Metronome.tsx` - Integrate BpmSlider component
- **Updated**: `frontend/src/App.css` - Add CSS styling for custom slider

## Test plan
- [x] All 32 BpmSlider and Metronome tests pass
- [x] Manual testing: verify slider thumb aligns with displayed BPM
- [x] Manual testing: verify tick marks appear at correct positions
- [ ] Manual testing: verify keyboard navigation works
- [ ] Manual testing: verify dark mode styling

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)