### PR TITLE
WIP: Articulation mode per scale/arpeggio (#31) + Selection sets (#41)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from database import SessionLocal, init_db
-from routes import arpeggios, practice, scales, settings
+from routes import arpeggios, practice, scales, selection_sets, settings
 from services.migrations import run_migrations
 from static_server import setup_static_serving
 
@@ -46,6 +46,7 @@ app.include_router(scales.router, prefix="/api", tags=["scales"])
 app.include_router(arpeggios.router, prefix="/api", tags=["arpeggios"])
 app.include_router(practice.router, prefix="/api", tags=["practice"])
 app.include_router(settings.router, prefix="/api", tags=["settings"])
+app.include_router(selection_sets.router, prefix="/api", tags=["selection-sets"])
 
 
 @app.get("/api/health")

--- a/backend/routes/selection_sets.py
+++ b/backend/routes/selection_sets.py
@@ -1,0 +1,242 @@
+"""Routes for managing selection sets (named repertoire configurations)."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import Arpeggio, Scale, SelectionSet
+
+router = APIRouter()
+
+
+class SelectionSetCreate(BaseModel):
+    """Request model for creating a selection set."""
+
+    name: str
+    scale_ids: list[int] = []
+    arpeggio_ids: list[int] = []
+
+
+class SelectionSetUpdate(BaseModel):
+    """Request model for updating a selection set."""
+
+    name: str
+    scale_ids: list[int] = []
+    arpeggio_ids: list[int] = []
+
+
+class SelectionSetResponse(BaseModel):
+    """Response model for selection set data."""
+
+    id: int
+    name: str
+    is_active: bool
+    scale_ids: list[int]
+    arpeggio_ids: list[int]
+    created_at: str
+    updated_at: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+@router.get("/selection-sets", response_model=list[SelectionSetResponse])
+async def get_selection_sets(db: Session = Depends(get_db)):
+    """Get all selection sets."""
+    sets = db.query(SelectionSet).order_by(SelectionSet.name).all()
+    return [
+        SelectionSetResponse(
+            id=s.id,
+            name=s.name,
+            is_active=s.is_active,
+            scale_ids=s.scale_ids or [],
+            arpeggio_ids=s.arpeggio_ids or [],
+            created_at=s.created_at.isoformat(),
+            updated_at=s.updated_at.isoformat(),
+        )
+        for s in sets
+    ]
+
+
+@router.get("/selection-sets/active", response_model=SelectionSetResponse | None)
+async def get_active_selection_set(db: Session = Depends(get_db)):
+    """Get the currently active selection set, if any."""
+    active_set = db.query(SelectionSet).filter(SelectionSet.is_active).first()
+    if not active_set:
+        return None
+    return SelectionSetResponse(
+        id=active_set.id,
+        name=active_set.name,
+        is_active=active_set.is_active,
+        scale_ids=active_set.scale_ids or [],
+        arpeggio_ids=active_set.arpeggio_ids or [],
+        created_at=active_set.created_at.isoformat(),
+        updated_at=active_set.updated_at.isoformat(),
+    )
+
+
+@router.get("/selection-sets/{set_id}", response_model=SelectionSetResponse)
+async def get_selection_set(set_id: int, db: Session = Depends(get_db)):
+    """Get a specific selection set by ID."""
+    selection_set = db.query(SelectionSet).filter(SelectionSet.id == set_id).first()
+    if not selection_set:
+        raise HTTPException(status_code=404, detail="Selection set not found")
+    return SelectionSetResponse(
+        id=selection_set.id,
+        name=selection_set.name,
+        is_active=selection_set.is_active,
+        scale_ids=selection_set.scale_ids or [],
+        arpeggio_ids=selection_set.arpeggio_ids or [],
+        created_at=selection_set.created_at.isoformat(),
+        updated_at=selection_set.updated_at.isoformat(),
+    )
+
+
+@router.post("/selection-sets", response_model=SelectionSetResponse)
+async def create_selection_set(data: SelectionSetCreate, db: Session = Depends(get_db)):
+    """Create a new selection set."""
+    # Check for duplicate name
+    existing = db.query(SelectionSet).filter(SelectionSet.name == data.name).first()
+    if existing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Selection set with name '{data.name}' already exists",
+        )
+
+    selection_set = SelectionSet(
+        name=data.name,
+        scale_ids=data.scale_ids,
+        arpeggio_ids=data.arpeggio_ids,
+    )
+    db.add(selection_set)
+    db.commit()
+    db.refresh(selection_set)
+
+    return SelectionSetResponse(
+        id=selection_set.id,
+        name=selection_set.name,
+        is_active=selection_set.is_active,
+        scale_ids=selection_set.scale_ids or [],
+        arpeggio_ids=selection_set.arpeggio_ids or [],
+        created_at=selection_set.created_at.isoformat(),
+        updated_at=selection_set.updated_at.isoformat(),
+    )
+
+
+@router.put("/selection-sets/{set_id}", response_model=SelectionSetResponse)
+async def update_selection_set(
+    set_id: int, data: SelectionSetUpdate, db: Session = Depends(get_db)
+):
+    """Update an existing selection set."""
+    selection_set = db.query(SelectionSet).filter(SelectionSet.id == set_id).first()
+    if not selection_set:
+        raise HTTPException(status_code=404, detail="Selection set not found")
+
+    # Check for duplicate name (excluding this set)
+    existing = (
+        db.query(SelectionSet)
+        .filter(SelectionSet.name == data.name, SelectionSet.id != set_id)
+        .first()
+    )
+    if existing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Selection set with name '{data.name}' already exists",
+        )
+
+    selection_set.name = data.name
+    selection_set.scale_ids = data.scale_ids
+    selection_set.arpeggio_ids = data.arpeggio_ids
+    db.commit()
+    db.refresh(selection_set)
+
+    return SelectionSetResponse(
+        id=selection_set.id,
+        name=selection_set.name,
+        is_active=selection_set.is_active,
+        scale_ids=selection_set.scale_ids or [],
+        arpeggio_ids=selection_set.arpeggio_ids or [],
+        created_at=selection_set.created_at.isoformat(),
+        updated_at=selection_set.updated_at.isoformat(),
+    )
+
+
+@router.delete("/selection-sets/{set_id}")
+async def delete_selection_set(set_id: int, db: Session = Depends(get_db)):
+    """Delete a selection set."""
+    selection_set = db.query(SelectionSet).filter(SelectionSet.id == set_id).first()
+    if not selection_set:
+        raise HTTPException(status_code=404, detail="Selection set not found")
+
+    db.delete(selection_set)
+    db.commit()
+    return {"deleted": True}
+
+
+@router.post("/selection-sets/{set_id}/load")
+async def load_selection_set(set_id: int, db: Session = Depends(get_db)):
+    """Load a selection set, enabling its items and disabling others.
+
+    This operation:
+    1. Deactivates all other selection sets
+    2. Marks this selection set as active
+    3. Enables all scales and arpeggios in the set
+    4. Disables all scales and arpeggios not in the set
+    """
+    selection_set = db.query(SelectionSet).filter(SelectionSet.id == set_id).first()
+    if not selection_set:
+        raise HTTPException(status_code=404, detail="Selection set not found")
+
+    # Deactivate all selection sets
+    db.query(SelectionSet).update({"is_active": False})
+
+    # Activate this set
+    selection_set.is_active = True
+
+    # Get the IDs from the set
+    scale_ids_set = set(selection_set.scale_ids or [])
+    arpeggio_ids_set = set(selection_set.arpeggio_ids or [])
+
+    # Enable scales in the set, disable others
+    scales_enabled = 0
+    scales_disabled = 0
+    for scale in db.query(Scale).all():
+        if scale.id in scale_ids_set:
+            if not scale.enabled:
+                scale.enabled = True
+            scales_enabled += 1
+        else:
+            if scale.enabled:
+                scale.enabled = False
+                scales_disabled += 1
+
+    # Enable arpeggios in the set, disable others
+    arpeggios_enabled = 0
+    arpeggios_disabled = 0
+    for arpeggio in db.query(Arpeggio).all():
+        if arpeggio.id in arpeggio_ids_set:
+            if not arpeggio.enabled:
+                arpeggio.enabled = True
+            arpeggios_enabled += 1
+        else:
+            if arpeggio.enabled:
+                arpeggio.enabled = False
+                arpeggios_disabled += 1
+
+    db.commit()
+
+    return {
+        "loaded": True,
+        "scales_enabled": scales_enabled,
+        "scales_disabled": scales_disabled,
+        "arpeggios_enabled": arpeggios_enabled,
+        "arpeggios_disabled": arpeggios_disabled,
+    }
+
+
+@router.post("/selection-sets/deactivate")
+async def deactivate_all_selection_sets(db: Session = Depends(get_db)):
+    """Deactivate all selection sets without changing item enabled states."""
+    count = db.query(SelectionSet).filter(SelectionSet.is_active).update({"is_active": False})
+    db.commit()
+    return {"deactivated_count": count}

--- a/backend/tests/test_selection_sets.py
+++ b/backend/tests/test_selection_sets.py
@@ -1,0 +1,501 @@
+"""Tests for selection sets functionality."""
+
+import pytest
+
+from models import Arpeggio, PracticeEntry, PracticeSession, Scale, SelectionSet
+
+
+class TestSelectionSetModel:
+    """Test the SelectionSet model."""
+
+    def test_create_selection_set(self, db):
+        """Test creating a basic selection set."""
+        selection_set = SelectionSet(
+            name="Test Set",
+            scale_ids=[1, 2, 3],
+            arpeggio_ids=[4, 5],
+        )
+        db.add(selection_set)
+        db.commit()
+        db.refresh(selection_set)
+
+        assert selection_set.id is not None
+        assert selection_set.name == "Test Set"
+        assert selection_set.scale_ids == [1, 2, 3]
+        assert selection_set.arpeggio_ids == [4, 5]
+        assert selection_set.is_active is False
+        assert selection_set.created_at is not None
+        assert selection_set.updated_at is not None
+
+    def test_selection_set_unique_name(self, db):
+        """Test that selection set names must be unique."""
+        set1 = SelectionSet(name="Unique Name", scale_ids=[], arpeggio_ids=[])
+        db.add(set1)
+        db.commit()
+
+        set2 = SelectionSet(name="Unique Name", scale_ids=[], arpeggio_ids=[])
+        db.add(set2)
+        with pytest.raises(Exception):
+            db.commit()
+
+    def test_selection_set_empty_ids(self, db):
+        """Test creating a selection set with empty ID lists."""
+        selection_set = SelectionSet(
+            name="Empty Set",
+            scale_ids=[],
+            arpeggio_ids=[],
+        )
+        db.add(selection_set)
+        db.commit()
+        db.refresh(selection_set)
+
+        assert selection_set.scale_ids == []
+        assert selection_set.arpeggio_ids == []
+
+
+class TestSelectionSetRoutes:
+    """Test selection set API routes."""
+
+    def test_get_selection_sets_empty(self, client):
+        """Test getting selection sets when none exist."""
+        response = client.get("/api/selection-sets")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_create_selection_set(self, client, db):
+        """Test creating a selection set via API."""
+        # Create some scales and arpeggios first
+        s1 = Scale(note="C", type="major", octaves=2, enabled=True)
+        s2 = Scale(note="D", type="minor_harmonic", octaves=2, enabled=True)
+        a1 = Arpeggio(note="G", type="major", octaves=2, enabled=True)
+        db.add_all([s1, s2, a1])
+        db.commit()
+        db.refresh(s1)
+        db.refresh(s2)
+        db.refresh(a1)
+
+        payload = {
+            "name": "My Practice Set",
+            "scale_ids": [s1.id, s2.id],
+            "arpeggio_ids": [a1.id],
+        }
+        response = client.post("/api/selection-sets", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "My Practice Set"
+        assert data["scale_ids"] == [s1.id, s2.id]
+        assert data["arpeggio_ids"] == [a1.id]
+        assert data["is_active"] is False
+        assert "id" in data
+
+    def test_create_selection_set_duplicate_name(self, client, db):
+        """Test that creating a set with duplicate name fails."""
+        payload = {"name": "Duplicate", "scale_ids": [], "arpeggio_ids": []}
+        response1 = client.post("/api/selection-sets", json=payload)
+        assert response1.status_code == 200
+
+        response2 = client.post("/api/selection-sets", json=payload)
+        assert response2.status_code == 400
+        assert "already exists" in response2.json()["detail"]
+
+    def test_get_selection_sets(self, client, db):
+        """Test getting all selection sets."""
+        set1 = SelectionSet(name="Set 1", scale_ids=[1], arpeggio_ids=[])
+        set2 = SelectionSet(name="Set 2", scale_ids=[], arpeggio_ids=[2])
+        db.add_all([set1, set2])
+        db.commit()
+
+        response = client.get("/api/selection-sets")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        names = [s["name"] for s in data]
+        assert "Set 1" in names
+        assert "Set 2" in names
+
+    def test_get_selection_set_by_id(self, client, db):
+        """Test getting a specific selection set."""
+        selection_set = SelectionSet(
+            name="Specific Set",
+            scale_ids=[1, 2],
+            arpeggio_ids=[3],
+        )
+        db.add(selection_set)
+        db.commit()
+        db.refresh(selection_set)
+
+        response = client.get(f"/api/selection-sets/{selection_set.id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Specific Set"
+        assert data["scale_ids"] == [1, 2]
+        assert data["arpeggio_ids"] == [3]
+
+    def test_get_selection_set_not_found(self, client):
+        """Test getting a non-existent selection set."""
+        response = client.get("/api/selection-sets/9999")
+        assert response.status_code == 404
+
+    def test_update_selection_set(self, client, db):
+        """Test updating a selection set."""
+        selection_set = SelectionSet(
+            name="Original Name",
+            scale_ids=[1],
+            arpeggio_ids=[2],
+        )
+        db.add(selection_set)
+        db.commit()
+        db.refresh(selection_set)
+
+        payload = {
+            "name": "Updated Name",
+            "scale_ids": [3, 4],
+            "arpeggio_ids": [5, 6],
+        }
+        response = client.put(
+            f"/api/selection-sets/{selection_set.id}",
+            json=payload,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Updated Name"
+        assert data["scale_ids"] == [3, 4]
+        assert data["arpeggio_ids"] == [5, 6]
+
+    def test_update_selection_set_not_found(self, client):
+        """Test updating a non-existent selection set."""
+        payload = {"name": "New Name", "scale_ids": [], "arpeggio_ids": []}
+        response = client.put("/api/selection-sets/9999", json=payload)
+        assert response.status_code == 404
+
+    def test_delete_selection_set(self, client, db):
+        """Test deleting a selection set."""
+        selection_set = SelectionSet(
+            name="To Delete",
+            scale_ids=[],
+            arpeggio_ids=[],
+        )
+        db.add(selection_set)
+        db.commit()
+        db.refresh(selection_set)
+
+        response = client.delete(f"/api/selection-sets/{selection_set.id}")
+        assert response.status_code == 200
+
+        # Verify it's deleted
+        response = client.get(f"/api/selection-sets/{selection_set.id}")
+        assert response.status_code == 404
+
+    def test_delete_selection_set_not_found(self, client):
+        """Test deleting a non-existent selection set."""
+        response = client.delete("/api/selection-sets/9999")
+        assert response.status_code == 404
+
+
+class TestLoadSelectionSet:
+    """Test loading a selection set."""
+
+    def test_load_selection_set(self, client, db):
+        """Test loading a selection set enables items and sets active."""
+        # Create scales and arpeggios
+        s1 = Scale(note="C", type="major", octaves=2, enabled=False)
+        s2 = Scale(note="D", type="minor_harmonic", octaves=2, enabled=True)
+        s3 = Scale(note="E", type="chromatic", octaves=2, enabled=True)
+        a1 = Arpeggio(note="G", type="major", octaves=2, enabled=False)
+        a2 = Arpeggio(note="A", type="minor", octaves=2, enabled=True)
+        db.add_all([s1, s2, s3, a1, a2])
+        db.commit()
+        db.refresh(s1)
+        db.refresh(s2)
+        db.refresh(s3)
+        db.refresh(a1)
+        db.refresh(a2)
+
+        # Create selection set with only s1, s2, a1
+        selection_set = SelectionSet(
+            name="Load Test",
+            scale_ids=[s1.id, s2.id],
+            arpeggio_ids=[a1.id],
+        )
+        db.add(selection_set)
+        db.commit()
+        db.refresh(selection_set)
+
+        # Load the selection set
+        response = client.post(f"/api/selection-sets/{selection_set.id}/load")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["scales_enabled"] == 2
+        assert data["arpeggios_enabled"] == 1
+        assert data["scales_disabled"] == 1  # s3
+        assert data["arpeggios_disabled"] == 1  # a2
+
+        # Verify in DB
+        db.refresh(s1)
+        db.refresh(s2)
+        db.refresh(s3)
+        db.refresh(a1)
+        db.refresh(a2)
+
+        assert s1.enabled is True
+        assert s2.enabled is True
+        assert s3.enabled is False
+        assert a1.enabled is True
+        assert a2.enabled is False
+
+        # Verify selection set is active
+        db.refresh(selection_set)
+        assert selection_set.is_active is True
+
+    def test_load_selection_set_deactivates_others(self, client, db):
+        """Test that loading a set deactivates other active sets."""
+        set1 = SelectionSet(
+            name="Set 1",
+            scale_ids=[],
+            arpeggio_ids=[],
+            is_active=True,
+        )
+        set2 = SelectionSet(
+            name="Set 2",
+            scale_ids=[],
+            arpeggio_ids=[],
+            is_active=False,
+        )
+        db.add_all([set1, set2])
+        db.commit()
+        db.refresh(set1)
+        db.refresh(set2)
+
+        # Load set2
+        response = client.post(f"/api/selection-sets/{set2.id}/load")
+        assert response.status_code == 200
+
+        # Verify set1 is no longer active, set2 is active
+        db.refresh(set1)
+        db.refresh(set2)
+        assert set1.is_active is False
+        assert set2.is_active is True
+
+    def test_load_selection_set_not_found(self, client):
+        """Test loading a non-existent selection set."""
+        response = client.post("/api/selection-sets/9999/load")
+        assert response.status_code == 404
+
+
+class TestActiveSelectionSet:
+    """Test active selection set functionality."""
+
+    def test_get_active_selection_set(self, client, db):
+        """Test getting the active selection set."""
+        set1 = SelectionSet(
+            name="Active Set",
+            scale_ids=[1, 2],
+            arpeggio_ids=[3],
+            is_active=True,
+        )
+        db.add(set1)
+        db.commit()
+
+        response = client.get("/api/selection-sets/active")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Active Set"
+        assert data["is_active"] is True
+
+    def test_get_active_selection_set_none(self, client, db):
+        """Test getting active set when none is active."""
+        set1 = SelectionSet(
+            name="Inactive Set",
+            scale_ids=[],
+            arpeggio_ids=[],
+            is_active=False,
+        )
+        db.add(set1)
+        db.commit()
+
+        response = client.get("/api/selection-sets/active")
+        assert response.status_code == 200
+        assert response.json() is None
+
+    def test_deactivate_all_selection_sets(self, client, db):
+        """Test deactivating all selection sets."""
+        set1 = SelectionSet(
+            name="Set 1",
+            scale_ids=[],
+            arpeggio_ids=[],
+            is_active=True,
+        )
+        set2 = SelectionSet(
+            name="Set 2",
+            scale_ids=[],
+            arpeggio_ids=[],
+            is_active=True,
+        )
+        db.add_all([set1, set2])
+        db.commit()
+        db.refresh(set1)
+        db.refresh(set2)
+
+        response = client.post("/api/selection-sets/deactivate")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deactivated_count"] == 2
+
+        # Verify in DB
+        db.refresh(set1)
+        db.refresh(set2)
+        assert set1.is_active is False
+        assert set2.is_active is False
+
+
+class TestPracticeSessionWithSelectionSet:
+    """Test practice session integration with selection sets."""
+
+    def test_practice_session_tracks_active_selection_set(self, client, db):
+        """Test that practice sessions track the active selection set."""
+        # Create scale and selection set
+        s1 = Scale(note="C", type="major", octaves=2, enabled=True)
+        db.add(s1)
+        db.commit()
+        db.refresh(s1)
+
+        selection_set = SelectionSet(
+            name="Active Set",
+            scale_ids=[s1.id],
+            arpeggio_ids=[],
+            is_active=True,
+        )
+        db.add(selection_set)
+        db.commit()
+        db.refresh(selection_set)
+
+        # Create practice session
+        payload = {
+            "entries": [
+                {
+                    "item_type": "scale",
+                    "item_id": s1.id,
+                    "articulation": "slurred",
+                    "was_practiced": True,
+                    "practiced_slurred": True,
+                    "practiced_separate": False,
+                }
+            ]
+        }
+        response = client.post("/api/practice-session", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["selection_set_id"] == selection_set.id
+
+        # Verify in DB
+        session = db.query(PracticeSession).first()
+        assert session.selection_set_id == selection_set.id
+
+    def test_practice_session_no_active_selection_set(self, client, db):
+        """Test practice session when no selection set is active."""
+        s1 = Scale(note="C", type="major", octaves=2, enabled=True)
+        db.add(s1)
+        db.commit()
+        db.refresh(s1)
+
+        payload = {
+            "entries": [
+                {
+                    "item_type": "scale",
+                    "item_id": s1.id,
+                    "articulation": "slurred",
+                    "was_practiced": True,
+                    "practiced_slurred": True,
+                    "practiced_separate": False,
+                }
+            ]
+        }
+        response = client.post("/api/practice-session", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["selection_set_id"] is None
+
+
+class TestPracticeHistoryWithSelectionSet:
+    """Test practice history filtering by selection set."""
+
+    def test_filter_practice_history_by_selection_set(self, client, db):
+        """Test filtering practice history by selection set ID."""
+        # Create scales
+        s1 = Scale(note="C", type="major", octaves=2, enabled=True, target_bpm=60)
+        s2 = Scale(note="D", type="minor_harmonic", octaves=2, enabled=True, target_bpm=60)
+        db.add_all([s1, s2])
+        db.commit()
+        db.refresh(s1)
+        db.refresh(s2)
+
+        # Create selection sets
+        set1 = SelectionSet(
+            name="Set 1",
+            scale_ids=[s1.id],
+            arpeggio_ids=[],
+        )
+        set2 = SelectionSet(
+            name="Set 2",
+            scale_ids=[s2.id],
+            arpeggio_ids=[],
+        )
+        db.add_all([set1, set2])
+        db.commit()
+        db.refresh(set1)
+        db.refresh(set2)
+
+        # Create practice sessions with different selection sets
+        session1 = PracticeSession(selection_set_id=set1.id)
+        session2 = PracticeSession(selection_set_id=set2.id)
+        db.add_all([session1, session2])
+        db.flush()
+
+        entry1 = PracticeEntry(
+            session_id=session1.id,
+            item_type="scale",
+            item_id=s1.id,
+            was_practiced=True,
+        )
+        entry2 = PracticeEntry(
+            session_id=session2.id,
+            item_type="scale",
+            item_id=s2.id,
+            was_practiced=True,
+        )
+        db.add_all([entry1, entry2])
+        db.commit()
+
+        # Filter by set1
+        response = client.get(f"/api/practice-history?selection_set_id={set1.id}")
+        assert response.status_code == 200
+        data = response.json()
+        # Should only contain s1 (from set1 sessions)
+        item_ids = [item["item_id"] for item in data if item["item_type"] == "scale"]
+        assert s1.id in item_ids
+        # s2 should only appear if it has practices outside set1 (it doesn't here)
+
+    def test_practice_history_no_filter(self, client, db):
+        """Test practice history without selection set filter returns all."""
+        s1 = Scale(note="C", type="major", octaves=2, enabled=True, target_bpm=60)
+        db.add(s1)
+        db.commit()
+        db.refresh(s1)
+
+        session = PracticeSession()
+        db.add(session)
+        db.flush()
+
+        entry = PracticeEntry(
+            session_id=session.id,
+            item_type="scale",
+            item_id=s1.id,
+            was_practiced=True,
+        )
+        db.add(entry)
+        db.commit()
+
+        response = client.get("/api/practice-history")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) >= 1

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1883,3 +1883,170 @@ tr:hover {
     opacity: 0.8;
   }
 }
+
+/* Selection Set Bar */
+.selection-set-bar {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  background: #f5f5f5;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.selection-set-dropdown {
+  flex: 1;
+  min-width: 200px;
+  max-width: 300px;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  background: white;
+}
+
+.selection-set-btn {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.selection-set-btn.save {
+  background: #4caf50;
+  color: white;
+}
+
+.selection-set-btn.save:hover {
+  background: #43a047;
+}
+
+.selection-set-btn.delete {
+  background: #f44336;
+  color: white;
+}
+
+.selection-set-btn.delete:hover {
+  background: #e53935;
+}
+
+.selection-set-btn.deactivate {
+  background: #9e9e9e;
+  color: white;
+}
+
+.selection-set-btn.deactivate:hover {
+  background: #757575;
+}
+
+/* Dialog Overlay */
+.dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.dialog {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 8px;
+  min-width: 300px;
+  max-width: 400px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+}
+
+.dialog h3 {
+  margin: 0 0 1rem 0;
+  font-size: 1.1rem;
+}
+
+.dialog input[type="text"] {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+  margin-bottom: 1rem;
+  box-sizing: border-box;
+}
+
+.dialog p {
+  margin: 0 0 1rem 0;
+  color: #666;
+}
+
+.dialog-buttons {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.dialog-buttons button {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+}
+
+.dialog-buttons button.primary {
+  background: #1976d2;
+  color: white;
+  border-color: #1976d2;
+}
+
+.dialog-buttons button.primary:disabled {
+  background: #ccc;
+  border-color: #ccc;
+  cursor: not-allowed;
+}
+
+.dialog-buttons button.danger {
+  background: #f44336;
+  color: white;
+  border-color: #f44336;
+}
+
+@media (prefers-color-scheme: dark) {
+  .selection-set-bar {
+    background: #333;
+  }
+
+  .selection-set-dropdown {
+    background: #444;
+    border-color: #555;
+    color: white;
+  }
+
+  .dialog {
+    background: #2a2a2a;
+    color: white;
+  }
+
+  .dialog input[type="text"] {
+    background: #333;
+    border-color: #444;
+    color: white;
+  }
+
+  .dialog p {
+    color: #aaa;
+  }
+
+  .dialog-buttons button {
+    background: #333;
+    border-color: #444;
+    color: white;
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, NavLink } from "react-router-dom";
 import { useEffect, useState } from "react";
 import ConfigPage from "./pages/ConfigPage";
 import PracticePage from "./pages/PracticePage";
+import { DeviceProvider } from "./contexts/DeviceContext";
 import { initDatabase } from "./api/client";
 import "./App.css";
 
@@ -37,31 +38,33 @@ function App() {
   }
 
   return (
-    <div className="app">
-      <header className="header">
-        <h1>Cello Scales Practice</h1>
-        <nav className="nav">
-          <NavLink
-            to="/"
-            className={({ isActive }) => (isActive ? "active" : "")}
-          >
-            Practice
-          </NavLink>
-          <NavLink
-            to="/config"
-            className={({ isActive }) => (isActive ? "active" : "")}
-          >
-            Config
-          </NavLink>
-        </nav>
-      </header>
-      <main className="main">
-        <Routes>
-          <Route path="/" element={<PracticePage />} />
-          <Route path="/config" element={<ConfigPage />} />
-        </Routes>
-      </main>
-    </div>
+    <DeviceProvider>
+      <div className="app">
+        <header className="header">
+          <h1>Cello Scales Practice</h1>
+          <nav className="nav">
+            <NavLink
+              to="/"
+              className={({ isActive }) => (isActive ? "active" : "")}
+            >
+              Practice
+            </NavLink>
+            <NavLink
+              to="/config"
+              className={({ isActive }) => (isActive ? "active" : "")}
+            >
+              Config
+            </NavLink>
+          </nav>
+        </header>
+        <main className="main">
+          <Routes>
+            <Route path="/" element={<PracticePage />} />
+            <Route path="/config" element={<ConfigPage />} />
+          </Routes>
+        </main>
+      </div>
+    </DeviceProvider>
   );
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -6,6 +6,9 @@ import type {
   SessionResponse,
   PracticeHistoryItem,
   AlgorithmConfig,
+  SelectionSet,
+  SelectionSetCreate,
+  SelectionSetUpdate,
 } from "../types";
 
 // Use relative URL - works in production (same origin) and dev (via Vite proxy)
@@ -168,6 +171,75 @@ export async function initDatabase(): Promise<{
 }> {
   return fetchJson<{ message: string; scales: number; arpeggios: number }>(
     `${API_BASE}/init-database`,
+    {
+      method: "POST",
+    }
+  );
+}
+
+// Selection Sets
+export async function getSelectionSets(): Promise<SelectionSet[]> {
+  return fetchJson<SelectionSet[]>(`${API_BASE}/selection-sets`);
+}
+
+export async function getActiveSelectionSet(): Promise<SelectionSet | null> {
+  return fetchJson<SelectionSet | null>(`${API_BASE}/selection-sets/active`);
+}
+
+export async function getSelectionSet(id: number): Promise<SelectionSet> {
+  return fetchJson<SelectionSet>(`${API_BASE}/selection-sets/${id}`);
+}
+
+export async function createSelectionSet(
+  data: SelectionSetCreate
+): Promise<SelectionSet> {
+  return fetchJson<SelectionSet>(`${API_BASE}/selection-sets`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateSelectionSet(
+  id: number,
+  data: SelectionSetUpdate
+): Promise<SelectionSet> {
+  return fetchJson<SelectionSet>(`${API_BASE}/selection-sets/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteSelectionSet(
+  id: number
+): Promise<{ deleted: boolean }> {
+  return fetchJson<{ deleted: boolean }>(`${API_BASE}/selection-sets/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export async function loadSelectionSet(id: number): Promise<{
+  loaded: boolean;
+  scales_enabled: number;
+  scales_disabled: number;
+  arpeggios_enabled: number;
+  arpeggios_disabled: number;
+}> {
+  return fetchJson<{
+    loaded: boolean;
+    scales_enabled: number;
+    scales_disabled: number;
+    arpeggios_enabled: number;
+    arpeggios_disabled: number;
+  }>(`${API_BASE}/selection-sets/${id}/load`, {
+    method: "POST",
+  });
+}
+
+export async function deactivateSelectionSets(): Promise<{
+  deactivated_count: number;
+}> {
+  return fetchJson<{ deactivated_count: number }>(
+    `${API_BASE}/selection-sets/deactivate`,
     {
       method: "POST",
     }

--- a/frontend/src/tests/SelectionSets.test.tsx
+++ b/frontend/src/tests/SelectionSets.test.tsx
@@ -1,0 +1,308 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import ConfigPage from "../pages/ConfigPage";
+
+// Mock the API client
+vi.mock("../api/client", () => ({
+  getScales: vi.fn().mockResolvedValue([
+    {
+      id: 1,
+      note: "C",
+      accidental: null,
+      type: "major",
+      octaves: 2,
+      enabled: true,
+      weight: 1.0,
+      target_bpm: null,
+      articulation_mode: "both",
+      display_name: "C major - 2 octaves",
+    },
+    {
+      id: 2,
+      note: "D",
+      accidental: null,
+      type: "minor_harmonic",
+      octaves: 2,
+      enabled: false,
+      weight: 1.0,
+      target_bpm: null,
+      articulation_mode: "both",
+      display_name: "D minor harmonic - 2 octaves",
+    },
+  ]),
+  getArpeggios: vi.fn().mockResolvedValue([
+    {
+      id: 1,
+      note: "G",
+      accidental: null,
+      type: "major",
+      octaves: 2,
+      enabled: true,
+      weight: 1.0,
+      target_bpm: null,
+      articulation_mode: "both",
+      display_name: "G major arpeggio - 2 octaves",
+    },
+  ]),
+  getAlgorithmConfig: vi.fn().mockResolvedValue({
+    config: {
+      total_items: 5,
+      variation: 20,
+      slots: [
+        { name: "Tonal Scales", types: ["major"], item_type: "scale", percent: 100 },
+      ],
+      octave_variety: true,
+      slurred_percent: 50,
+      weighting: {
+        base_multiplier: 1.0,
+        days_since_practice_factor: 7,
+        practice_count_divisor: 1,
+      },
+      default_scale_bpm: 60,
+      default_arpeggio_bpm: 72,
+      scale_bpm_unit: "crotchet",
+      arpeggio_bpm_unit: "quaver",
+      weekly_focus: {
+        enabled: false,
+        keys: [],
+        types: [],
+        categories: [],
+        probability_increase: 80,
+      },
+    },
+  }),
+  getSelectionSets: vi.fn().mockResolvedValue([]),
+  getActiveSelectionSet: vi.fn().mockResolvedValue(null),
+  createSelectionSet: vi.fn().mockResolvedValue({
+    id: 1,
+    name: "Test Set",
+    is_active: false,
+    scale_ids: [1],
+    arpeggio_ids: [1],
+    created_at: "2024-01-01T00:00:00",
+    updated_at: "2024-01-01T00:00:00",
+  }),
+  updateSelectionSet: vi.fn().mockResolvedValue({}),
+  deleteSelectionSet: vi.fn().mockResolvedValue({ deleted: true }),
+  loadSelectionSet: vi.fn().mockResolvedValue({
+    loaded: true,
+    scales_enabled: 1,
+    scales_disabled: 1,
+    arpeggios_enabled: 1,
+    arpeggios_disabled: 0,
+  }),
+  deactivateSelectionSets: vi.fn().mockResolvedValue({ deactivated_count: 1 }),
+  updateAlgorithmConfig: vi.fn().mockResolvedValue({}),
+  updateScale: vi.fn(),
+  updateArpeggio: vi.fn(),
+  bulkEnableScales: vi.fn(),
+  bulkEnableArpeggios: vi.fn(),
+  bulkArticulationScales: vi.fn(),
+  bulkArticulationArpeggios: vi.fn(),
+  resetAlgorithmConfig: vi.fn(),
+}));
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={createQueryClient()}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe("ConfigPage - Selection Sets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render the selection set bar on Repertoire tab", async () => {
+    render(<ConfigPage />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Select a set...")).toBeInTheDocument();
+    });
+  });
+
+  it("should show Save button", async () => {
+    render(<ConfigPage />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    });
+  });
+
+  it("should open save dialog when Save button is clicked", async () => {
+    render(<ConfigPage />, { wrapper });
+
+    await waitFor(() => screen.getByRole("button", { name: "Save" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Save Selection Set")).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("Enter set name...")).toBeInTheDocument();
+    });
+  });
+
+  it("should call createSelectionSet when saving a new set", async () => {
+    const { createSelectionSet } = await import("../api/client");
+
+    render(<ConfigPage />, { wrapper });
+
+    await waitFor(() => screen.getByRole("button", { name: "Save" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => screen.getByPlaceholderText("Enter set name..."));
+
+    const input = screen.getByPlaceholderText("Enter set name...");
+    fireEvent.change(input, { target: { value: "My New Set" } });
+
+    // Click the save button in the dialog
+    const dialogSaveButton = screen.getAllByRole("button", { name: "Save" })[1];
+    fireEvent.click(dialogSaveButton);
+
+    await waitFor(() => {
+      expect(createSelectionSet).toHaveBeenCalledWith({
+        name: "My New Set",
+        scale_ids: [1], // Only C major is enabled
+        arpeggio_ids: [1], // G major arpeggio is enabled
+      });
+    });
+  });
+
+  it("should display selection sets in the dropdown", async () => {
+    const { getSelectionSets } = await import("../api/client");
+    (getSelectionSets as Mock).mockResolvedValueOnce([
+      {
+        id: 1,
+        name: "Practice Set A",
+        is_active: false,
+        scale_ids: [1],
+        arpeggio_ids: [],
+        created_at: "2024-01-01T00:00:00",
+        updated_at: "2024-01-01T00:00:00",
+      },
+      {
+        id: 2,
+        name: "Practice Set B",
+        is_active: true,
+        scale_ids: [2],
+        arpeggio_ids: [1],
+        created_at: "2024-01-01T00:00:00",
+        updated_at: "2024-01-01T00:00:00",
+      },
+    ]);
+
+    render(<ConfigPage />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Practice Set A")).toBeInTheDocument();
+      expect(screen.getByText("Practice Set B (active)")).toBeInTheDocument();
+    });
+  });
+
+  it("should call loadSelectionSet when selecting a set from dropdown", async () => {
+    const { getSelectionSets, loadSelectionSet } = await import("../api/client");
+    (getSelectionSets as Mock).mockResolvedValue([
+      {
+        id: 1,
+        name: "Test Set",
+        is_active: false,
+        scale_ids: [1],
+        arpeggio_ids: [],
+        created_at: "2024-01-01T00:00:00",
+        updated_at: "2024-01-01T00:00:00",
+      },
+    ]);
+
+    render(<ConfigPage />, { wrapper });
+
+    await waitFor(() => screen.getByText("Test Set"));
+
+    const dropdown = screen.getByRole("combobox", { hidden: true }) as HTMLSelectElement;
+    fireEvent.change(dropdown, { target: { value: "1" } });
+
+    await waitFor(() => {
+      expect(loadSelectionSet).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it("should show Delete and Deactivate buttons when a set is active", async () => {
+    const { getActiveSelectionSet } = await import("../api/client");
+    (getActiveSelectionSet as Mock).mockResolvedValueOnce({
+      id: 1,
+      name: "Active Set",
+      is_active: true,
+      scale_ids: [1],
+      arpeggio_ids: [],
+      created_at: "2024-01-01T00:00:00",
+      updated_at: "2024-01-01T00:00:00",
+    });
+
+    render(<ConfigPage />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Deactivate" })).toBeInTheDocument();
+    });
+  });
+
+  it("should call deactivateSelectionSets when Deactivate button is clicked", async () => {
+    const { getActiveSelectionSet, deactivateSelectionSets } = await import(
+      "../api/client"
+    );
+    (getActiveSelectionSet as Mock).mockResolvedValueOnce({
+      id: 1,
+      name: "Active Set",
+      is_active: true,
+      scale_ids: [1],
+      arpeggio_ids: [],
+      created_at: "2024-01-01T00:00:00",
+      updated_at: "2024-01-01T00:00:00",
+    });
+
+    render(<ConfigPage />, { wrapper });
+
+    await waitFor(() => screen.getByRole("button", { name: "Deactivate" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Deactivate" }));
+
+    await waitFor(() => {
+      expect(deactivateSelectionSets).toHaveBeenCalled();
+    });
+  });
+
+  it("should show delete confirmation dialog when Delete button is clicked", async () => {
+    const { getActiveSelectionSet } = await import("../api/client");
+    (getActiveSelectionSet as Mock).mockResolvedValueOnce({
+      id: 1,
+      name: "Active Set",
+      is_active: true,
+      scale_ids: [1],
+      arpeggio_ids: [],
+      created_at: "2024-01-01T00:00:00",
+      updated_at: "2024-01-01T00:00:00",
+    });
+
+    render(<ConfigPage />, { wrapper });
+
+    await waitFor(() => screen.getByRole("button", { name: "Delete" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete Selection Set")).toBeInTheDocument();
+      expect(
+        screen.getByText(/Are you sure you want to delete "Active Set"/)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -49,6 +49,29 @@ export interface SessionResponse {
   created_at: string;
   entries_count: number;
   practiced_count: number;
+  selection_set_id: number | null;
+}
+
+export interface SelectionSet {
+  id: number;
+  name: string;
+  is_active: boolean;
+  scale_ids: number[];
+  arpeggio_ids: number[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SelectionSetCreate {
+  name: string;
+  scale_ids: number[];
+  arpeggio_ids: number[];
+}
+
+export interface SelectionSetUpdate {
+  name: string;
+  scale_ids: number[];
+  arpeggio_ids: number[];
 }
 
 export interface PracticeHistoryItem {


### PR DESCRIPTION
## Status: Draft - Mixed WIP

This branch contains **mixed incomplete work** from parallel agents for:
- **Issue #31**: Per-item articulation mode (separate only / both)
- **Issue #41**: Named selection sets

### What's here
- SelectionSet model and API routes (issue #41)
- Articulation mode references in arpeggios/scales routes (issue #31)
- ConfigPage UI changes (both issues)
- Tests for selection sets

### What's missing / broken
- `ArticulationToggle` component not created yet
- `DeviceContext` not created yet
- `articulation_mode` field not in Scale/Arpeggio models yet
- Backend tests fail (2 failures in arpeggios)
- Frontend TypeScript errors

### Next steps
1. Separate changes into dedicated branches for #31 and #41
2. Complete each implementation independently
3. Fix tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)